### PR TITLE
removed python_version from Pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,4 +13,3 @@ python-dateutil = "*"
 [dev-packages]
 
 [requires]
-python_version = "3.6"


### PR DESCRIPTION
It turns out there is no way in pipenv to specify the
python versions your package is meant to work with, unless
you want to specify a very specific <major>.<minor> using
python_version or a very specific <major>.<minor>.<revision>
using python_full_version.

The current official word on the matter is to simply omit a
python_version, it seems. Fair enough!

fixes #4 